### PR TITLE
Request from kecc maintainers

### DIFF
--- a/request_from_maintainers
+++ b/request_from_maintainers
@@ -1,0 +1,2 @@
+Please check the description in PR message :)
+After following our request, you may freely delete this file.


### PR DESCRIPTION
Hello, we are maintainers of kaist-cp/kecc-public repository, from kaist-cp laboratory.

As the repository's description states, we do not allow public fork of the public repo. We adopt this policy because kecc is an assignment of KAIST's undergraduate compiler design course, and the allowance of a public fork can threaten academic integrity (since people can push their work online). So, can you make your public fork private or remove the forked repository?

Thank you so much for your attention and participation. 
kecc maintainers